### PR TITLE
Fix layout bugs in Profile Page

### DIFF
--- a/src/components/Sidebar/style.tsx
+++ b/src/components/Sidebar/style.tsx
@@ -1,9 +1,10 @@
 import styled from "styled-components";
 
 const StyledSidebar = styled.div`
-  width: 30rem;
+  width: 20rem;
   height: 100vh;
-  background-color: ${(props) => props.theme.color.secondryBgColor};
+  flex-shrink: 0;
+  background-color: ${(props) => props.theme.color.secondaryBgColor};
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/components/Sidebar/style.tsx
+++ b/src/components/Sidebar/style.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 const StyledSidebar = styled.div`
-  width: 25%;
+  width: 30rem;
   height: 100vh;
   background-color: ${(props) => props.theme.color.secondryBgColor};
   display: flex;

--- a/src/components/TournamentCard/TournamentCard.tsx
+++ b/src/components/TournamentCard/TournamentCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { FaUserGroup, FaBolt, FaRankingStar } from "react-icons/fa6";
-import { Card, CardHeader, Title, ParticipantInfo, Icon, Text, Date, BoldText } from "./style";
+import { Card, CardHeader, CardContent, Title, ParticipantInfo, Icon, Text, Date, BoldText } from "./style";
 import type { TournamentCardProps } from "../../types/tournamentCardTypes";
 
 const TournamentCard = ({ tournament }: TournamentCardProps): React.JSX.Element => {
@@ -10,7 +10,8 @@ const TournamentCard = ({ tournament }: TournamentCardProps): React.JSX.Element 
         <Title>{tournament.title}</Title>
         <Date>{tournament.date}</Date>
       </CardHeader>
-      <ParticipantInfo>
+      <CardContent>
+        <ParticipantInfo>
         <Icon>
           <FaUserGroup />
         </Icon>
@@ -33,6 +34,7 @@ const TournamentCard = ({ tournament }: TournamentCardProps): React.JSX.Element 
         </Icon>
         <BoldText>{tournament.status}</BoldText>
       </ParticipantInfo>
+      </CardContent>
     </Card>
   );
 };

--- a/src/components/TournamentCard/TournamentCard.tsx
+++ b/src/components/TournamentCard/TournamentCard.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 import { FaUserGroup, FaBolt, FaRankingStar } from "react-icons/fa6";
-import { Card, CardHeader, CardContent, Title, ParticipantInfo, Icon, Text, Date, BoldText } from "./style";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  Title,
+  ParticipantInfo,
+  Icon,
+  Text,
+  Date,
+  BoldText,
+} from "./style";
 import type { TournamentCardProps } from "../../types/tournamentCardTypes";
 
 const TournamentCard = ({ tournament }: TournamentCardProps): React.JSX.Element => {
@@ -12,28 +22,28 @@ const TournamentCard = ({ tournament }: TournamentCardProps): React.JSX.Element 
       </CardHeader>
       <CardContent>
         <ParticipantInfo>
-        <Icon>
-          <FaUserGroup />
-        </Icon>
-        <Text>
-          <BoldText>{tournament.n_participants}</BoldText> participants
-        </Text>
-      </ParticipantInfo>
-      <ParticipantInfo>
-        <Icon>
-          <FaBolt />
-        </Icon>
-        <Text>
-          <BoldText>{tournament.n_games}</BoldText> games played
-        </Text>
-      </ParticipantInfo>
+          <Icon>
+            <FaUserGroup />
+          </Icon>
+          <Text>
+            <BoldText>{tournament.n_participants}</BoldText> participants
+          </Text>
+        </ParticipantInfo>
+        <ParticipantInfo>
+          <Icon>
+            <FaBolt />
+          </Icon>
+          <Text>
+            <BoldText>{tournament.n_games}</BoldText> games played
+          </Text>
+        </ParticipantInfo>
 
-      <ParticipantInfo>
-        <Icon>
-          <FaRankingStar />
-        </Icon>
-        <BoldText>{tournament.status}</BoldText>
-      </ParticipantInfo>
+        <ParticipantInfo>
+          <Icon>
+            <FaRankingStar />
+          </Icon>
+          <BoldText>{tournament.status}</BoldText>
+        </ParticipantInfo>
       </CardContent>
     </Card>
   );

--- a/src/components/TournamentCard/style.tsx
+++ b/src/components/TournamentCard/style.tsx
@@ -1,19 +1,23 @@
 import styled from "styled-components";
-import { globalRegularFontStyles, globalSemiBoldFontStyles, globalBoldFontStyles } from "../../theme/FontStyles";
+import {
+  globalRegularFontStyles,
+  globalSemiBoldFontStyles,
+  globalBoldFontStyles,
+} from "../../theme/FontStyles";
 
 const Card = styled.div`
   box-sizing: border-box;
   flex-shrink: 0;
   padding: 1.25rem 1.25rem 1.25rem 1.87rem;
   margin: 1.25rem 5rem 1.25rem 5rem;
-  
+
   width: 50rem;
   height: 11rem;
   background-color: ${(props) => props.theme.color.bgColor};
-  
+
   border-radius: 1.25rem;
   box-shadow: 0 0 4px 2px rgba(0, 0, 0, 0.25);
-  
+
   &:hover {
     box-shadow: 0 0 8px 4px rgba(0, 0, 0, 0.25);
   }

--- a/src/components/TournamentCard/style.tsx
+++ b/src/components/TournamentCard/style.tsx
@@ -10,7 +10,7 @@ const Card = styled.div`
   padding: 1rem 2rem;
   width: 60rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
-  margin-bottom: 2%;
+  margin: 1rem 0;
   &:hover {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
   }

--- a/src/components/TournamentCard/style.tsx
+++ b/src/components/TournamentCard/style.tsx
@@ -1,18 +1,21 @@
 import styled from "styled-components";
-import { globalRegularFontStyles, globalBoldFontStyles } from "../../theme/FontStyles";
+import { globalRegularFontStyles, globalSemiBoldFontStyles, globalBoldFontStyles } from "../../theme/FontStyles";
 
 const Card = styled.div`
-  display: flex;
-  flex-direction: column;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  padding: 1.25rem 1.25rem 1.25rem 1.87rem;
+  margin: 1.25rem 5rem 1.25rem 5rem;
+  
+  width: 50rem;
+  height: 11rem;
   background-color: ${(props) => props.theme.color.bgColor};
-  border: 1.5px solid #ccc;
-  border-radius: 20px;
-  padding: 1rem 2rem;
-  width: 60rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
-  margin: 1rem 0;
+  
+  border-radius: 1.25rem;
+  box-shadow: 0 0 4px 2px rgba(0, 0, 0, 0.25);
+  
   &:hover {
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 0 8px 4px rgba(0, 0, 0, 0.25);
   }
 `;
 
@@ -20,23 +23,31 @@ const CardHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
+`;
+
+const CardContent = styled.div`
+  /* background-color: black; */
+  height: 7.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
 `;
 
 const Title = styled.h1`
-  ${globalBoldFontStyles};
+  ${globalSemiBoldFontStyles};
   color: ${(props) => props.theme.color.mainColor};
-  font-size: 2rem;
+  font-size: 1.56rem;
 `;
 
 const Text = styled.span`
   ${globalRegularFontStyles};
-  font-size: 1.5rem;
+  font-size: 1.25rem;
 `;
 const Date = styled(Text)`
   ${globalRegularFontStyles};
   text-align: right;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
 `;
 
 const ParticipantInfo = styled.div`
@@ -44,17 +55,16 @@ const ParticipantInfo = styled.div`
   align-items: center;
   justify-content: flex-start;
   gap: 0.5rem;
-  margin-bottom: 0.5rem;
 `;
 
 const Icon = styled.span`
   color: ${(props) => props.theme.color.notActiveColor};
-  font-size: 1.75rem;
+  font-size: 1.25rem;
 `;
 
 const BoldText = styled.span`
   ${globalBoldFontStyles};
-  font-size: 1.5rem;
+  font-size: 1.25rem;
 `;
 
-export { Card, CardHeader, Title, ParticipantInfo, Icon, Text, Date, BoldText };
+export { Card, CardHeader, CardContent, Title, ParticipantInfo, Icon, Text, Date, BoldText };

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -18,6 +18,9 @@ import Sidebar from "../../components/Sidebar/Sidebar";
 import { TbLogout2 } from "react-icons/tb";
 import { FaUserCircle } from "react-icons/fa";
 import { Link } from "react-router-dom";
+import { IoAddCircleSharp } from "react-icons/io5";
+import { GrFormAdd } from "react-icons/gr";
+import { VscAdd } from "react-icons/vsc";
 
 const ProfilePage = (): React.JSX.Element => {
   const [activeTab, setActiveTab] = useState("active");
@@ -130,7 +133,9 @@ const ProfilePage = (): React.JSX.Element => {
         </TournamentSlider>
         <CreateTournamentButton>
           Create tournament
-          <CreateIcon>+</CreateIcon>
+          <CreateIcon>
+            <svg stroke="#fff" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1.5em" width="1.5em" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke="#FFF" stroke-width="2" d="M12,18 L12,6 M6,12 L18,12"></path></svg>
+          </CreateIcon>
         </CreateTournamentButton>
       </Sidebar>
 

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -20,7 +20,6 @@ import { FaUserCircle } from "react-icons/fa";
 import { MdAdd } from "react-icons/md";
 import { Link } from "react-router-dom";
 
-
 const ProfilePage = (): React.JSX.Element => {
   const [activeTab, setActiveTab] = useState("active");
   const userEmail = "emailemail@gmail.com";
@@ -139,9 +138,8 @@ const ProfilePage = (): React.JSX.Element => {
       </Sidebar>
 
       <MainContent>
-        <EmptyBox/>
-        {
-        activeTab === "active"
+        <EmptyBox />
+        {activeTab === "active"
           ? activeTournaments.map((tournament, index) => (
               <TournamentCard key={index} tournament={tournament}></TournamentCard>
             ))

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -17,10 +17,9 @@ import {
 import Sidebar from "../../components/Sidebar/Sidebar";
 import { TbLogout2 } from "react-icons/tb";
 import { FaUserCircle } from "react-icons/fa";
+import { MdAdd } from "react-icons/md";
 import { Link } from "react-router-dom";
-import { IoAddCircleSharp } from "react-icons/io5";
-import { GrFormAdd } from "react-icons/gr";
-import { VscAdd } from "react-icons/vsc";
+
 
 const ProfilePage = (): React.JSX.Element => {
   const [activeTab, setActiveTab] = useState("active");
@@ -134,7 +133,7 @@ const ProfilePage = (): React.JSX.Element => {
         <CreateTournamentButton>
           Create tournament
           <CreateIcon>
-            <svg stroke="#fff" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1.5em" width="1.5em" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke="#FFF" stroke-width="2" d="M12,18 L12,6 M6,12 L18,12"></path></svg>
+            <MdAdd />
           </CreateIcon>
         </CreateTournamentButton>
       </Sidebar>

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -12,6 +12,7 @@ import {
   EmailText,
   CreateTournamentButton,
   CreateIcon,
+  EmptyBox,
 } from "./style";
 import Sidebar from "../../components/Sidebar/Sidebar";
 import { TbLogout2 } from "react-icons/tb";
@@ -131,7 +132,9 @@ const ProfilePage = (): React.JSX.Element => {
       </Sidebar>
 
       <MainContent>
-        {activeTab === "active"
+        <EmptyBox/>
+        {
+        activeTab === "active"
           ? activeTournaments.map((tournament, index) => (
               <TournamentCard key={index} tournament={tournament}></TournamentCard>
             ))

--- a/src/pages/ProfilePage/style.tsx
+++ b/src/pages/ProfilePage/style.tsx
@@ -78,7 +78,7 @@ const TournamentTab = styled.button<TournamentTabProps>`
   border-right: 0.5rem solid
     ${(props) => (props.$active ? props.theme.color.mainColor : props.theme.color.secondryBgColor)};
 
-  ${(props) => (props.active ? globalSemiBoldFontStyles : globalRegularFontStyles)}
+  ${(props) => (props.$active ? globalSemiBoldFontStyles : globalRegularFontStyles)};
   font-size: 1.8rem;
 
   color: ${(props) =>

--- a/src/pages/ProfilePage/style.tsx
+++ b/src/pages/ProfilePage/style.tsx
@@ -17,7 +17,7 @@ const ProfileLogo = styled.div`
   position: absolute;
   top: 1.25rem;
   right: 1.25rem;
-  
+
   height: 2.5rem;
   width: 2.5rem;
   font-size: 2.5rem;
@@ -83,9 +83,8 @@ const TournamentTab = styled.button<TournamentTabProps>`
 
   border-right: 0.5rem solid
     ${(props) => (props.$active ? props.theme.color.mainColor : props.theme.color.secondaryBgColor)};
-  
 
-  ${(globalRegularFontStyles)};
+  ${globalRegularFontStyles};
   /* ${(props) => (props.$active ? globalSemiBoldFontStyles : globalRegularFontStyles)}; */
   font-size: 1.25rem;
 
@@ -127,7 +126,7 @@ const CreateIcon = styled.div`
   align-items: center;
   justify-content: space-around;
   border-radius: 50%;
-  background-color: ${props => props.theme.color.mainColor};
+  background-color: ${(props) => props.theme.color.mainColor};
   ${globalRegularFontStyles};
   width: 1.875rem;
   height: 1.875rem;

--- a/src/pages/ProfilePage/style.tsx
+++ b/src/pages/ProfilePage/style.tsx
@@ -25,7 +25,6 @@ const ProfileLogo = styled.div`
 `;
 
 const MainContent = styled.div`
-  margin-top: 8rem;
   padding: 0rem 10rem 0rem 5rem;
   height: 100vh;
   overflow-y: scroll;
@@ -80,7 +79,7 @@ const TournamentTab = styled.button<TournamentTabProps>`
     ${(props) => (props.active ? props.theme.color.mainColor : props.theme.color.secondryBgColor)};
 
   ${(props) => (props.active ? globalSemiBoldFontStyles : globalRegularFontStyles)}
-  font-size: 2rem;
+  font-size: 1.8rem;
   color: ${(props) =>
     props.active ? props.theme.color.mainColor : props.theme.color.notActiveColor};
 
@@ -126,7 +125,13 @@ const CreateIcon = styled.span`
   padding-bottom: 0.2rem;
 `;
 
+const EmptyBox = styled.div`
+  height: 12.5rem;
+  background: none;
+`;
+
 export {
+  EmptyBox,
   ProfileContainer,
   ProfileLogo,
   MainContent,

--- a/src/pages/ProfilePage/style.tsx
+++ b/src/pages/ProfilePage/style.tsx
@@ -15,17 +15,17 @@ const ProfileContainer = styled.div`
 
 const ProfileLogo = styled.div`
   position: absolute;
-  top: 0;
-  right: 0;
-  margin: 2rem 3rem;
-  font-size: 3.5rem;
+  top: 1.25rem;
+  right: 1.25rem;
+  
+  height: 2.5rem;
+  width: 2.5rem;
+  font-size: 2.5rem;
   color: ${(props) => props.theme.color.mainColor};
-  z-index: 10;
   cursor: pointer;
 `;
 
 const MainContent = styled.div`
-  padding: 0rem 10rem 0rem 5rem;
   height: 100vh;
   overflow-y: scroll;
   flex-grow: 1;
@@ -35,28 +35,33 @@ const MainContent = styled.div`
 `;
 
 const LogoutButton = styled.button`
+  position: absolute;
+  top: 2.5rem;
+  left: 2.5rem;
+  gap: 0.5rem;
   display: flex;
-  width: 10rem;
   align-items: center;
   background: none;
   border: none;
+  ${globalSemiBoldFontStyles};
   color: ${(props) => props.theme.color.mainColor};
-  font-size: 1.75rem;
-  font-weight: bold;
-  margin: 2rem;
   cursor: pointer;
 `;
 
 const LogoutIcon = styled.span`
-  margin-right: 0.5rem;
+  ${globalSemiBoldFontStyles};
+  display: flex;
+  width: 1.5rem;
+  height: 1.5rem;
+  justify-content: center;
+  align-items: center;
 `;
 
 const EmailText = styled.div`
   align-self: self-end;
-  margin-right: 1rem;
-  padding-right: 2rem;
+  margin-right: 1.75rem;
   ${globalRegularFontStyles}
-  font-size: 2rem;
+  font-size: 1.25rem;
 `;
 
 const TournamentSlider = styled.div`
@@ -71,15 +76,18 @@ const TournamentTab = styled.button<TournamentTabProps>`
   cursor: pointer;
 
   align-self: self-end;
-  width: 23rem;
+  justify-content: center;
+  width: 15rem;
   text-align: right;
-  padding: 1rem 2.5rem 0rem 0;
+  padding: 0.5rem 1.75rem 0.5rem 0;
 
   border-right: 0.5rem solid
-    ${(props) => (props.$active ? props.theme.color.mainColor : props.theme.color.secondryBgColor)};
+    ${(props) => (props.$active ? props.theme.color.mainColor : props.theme.color.secondaryBgColor)};
+  
 
-  ${(props) => (props.$active ? globalSemiBoldFontStyles : globalRegularFontStyles)};
-  font-size: 1.8rem;
+  ${(globalRegularFontStyles)};
+  /* ${(props) => (props.$active ? globalSemiBoldFontStyles : globalRegularFontStyles)}; */
+  font-size: 1.25rem;
 
   color: ${(props) =>
     props.$active ? props.theme.color.mainColor : props.theme.color.notActiveColor};
@@ -91,9 +99,9 @@ const TournamentTab = styled.button<TournamentTabProps>`
 
 const CreateTournamentButton = styled.button`
   display: flex;
-  margin-bottom: 1rem;
+  margin-bottom: 2.5rem;
   align-self: self-end;
-  align-items: end;
+  align-items: center;
   flex-direction: row;
   justify-content: space-between;
   border: none;
@@ -104,8 +112,9 @@ const CreateTournamentButton = styled.button`
   cursor: pointer;
   ${globalRegularFontStyles}
   color: ${(props) => props.theme.color.fontColor};
-  font-size: 2rem;
-  width: 21rem;
+  font-size: 1.25rem;
+  width: 15rem;
+  height: 2.5rem;
   &:hover {
     border-radius: 6.25rem;
     color: ${(props) => props.theme.color.bgColor};
@@ -113,21 +122,21 @@ const CreateTournamentButton = styled.button`
   }
 `;
 
-const CreateIcon = styled.span`
+const CreateIcon = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-around;
   border-radius: 50%;
-  background-color: ${(props) => props.theme.color.mainColor};
-  color: ${(props) => props.theme.color.bgColor};
-  width: 2.5rem;
-  height: 2.3rem;
-  font-size: 2rem;
-  padding-bottom: 0.2rem;
+  background-color: ${props => props.theme.color.mainColor};
+  ${globalRegularFontStyles};
+  width: 1.875rem;
+  height: 1.875rem;
+  margin-right: 0.5rem;
+  font-size: 1.25rem;
 `;
 
 const EmptyBox = styled.div`
-  height: 12.5rem;
+  height: 8rem;
   background: none;
 `;
 

--- a/src/pages/ProfilePage/style.tsx
+++ b/src/pages/ProfilePage/style.tsx
@@ -103,7 +103,7 @@ const CreateTournamentButton = styled.button`
   align-self: self-end;
   align-items: center;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: space-evenly;
   border: none;
   background: none;
   border-radius: 50%;
@@ -131,8 +131,8 @@ const CreateIcon = styled.div`
   ${globalRegularFontStyles};
   width: 1.875rem;
   height: 1.875rem;
-  margin-right: 0.5rem;
-  font-size: 1.25rem;
+  font-size: 1.5rem;
+  color: white;
 `;
 
 const EmptyBox = styled.div`


### PR DESCRIPTION
Fixed the following:

- Adjusting sidebar size using rem .
- Label "Archived tournaments" splitting into 2 lines when active.
- Dead space on top of the tournaments card (even when scrolling).